### PR TITLE
queryselector name change

### DIFF
--- a/Main/views/profile.handlebars
+++ b/Main/views/profile.handlebars
@@ -8,7 +8,7 @@
   <div class="col-md-6">
     <h3>Create a New Project:</h3>
 
-    <form class="form new-BlogPost">
+    <form class="form new-project-form">
       <div class="form-group">
         <label for="project-name">project name:</label>
         <input class="form-input" type="text" id="project-name" name="project-name" />


### PR DESCRIPTION
new-blogpost to new-project-form